### PR TITLE
Added VirtualBox Shares Enumeration technique

### DIFF
--- a/techniques/VboxEnumShares/README.md
+++ b/techniques/VboxEnumShares/README.md
@@ -1,0 +1,14 @@
+# *VboxEnumShares*
+
+## Authorship information
+* Nickname: *HoIIovv*
+* Twitter: https://twitter.com/HoIIovv
+* Website: https://nicolabottura.github.io/
+* Linkedin: https://www.linkedin.com/in/nicola-bottura/
+  
+## Technique Information
+* Technique title: VboxEnumShares
+* Technique category: Anti-VM
+* Technique Description: This method represents a variation of the `WNetGetProviderName(WNNC_NET_RDR2SAMPLE, ...)` approach, which is typically employed to determine if the network share's provider name is specific, such as VirtualBox. Instead of relying on this well-established technique, we utilize `WNetOpenEnum` and `WNetEnumResource` functions to iterate through each network resource. The primary objective is to identify VirtualBox shared folders, which typically feature "VirtualBox" or "VBoxSrv" substrings in their names. The latter, VBoxSrv, serves as a pseudo-network redirector provided by VirtualBox, enabling access to shared folders within the guest OS. These folders are sub-resources of the VirtualBox Shared Folder resource. By systematically enumerating these folders, a malware sample can ascertain the presence of the hypervisor in an alternative manner.
+
+YARA rules are not provided due to the potential for false positives when searching for the two mentioned APIs. However, it's important to consider these APIs during the analysis of evasive samples.

--- a/techniques/VboxEnumShares/VboxEnumShares.cpp
+++ b/techniques/VboxEnumShares/VboxEnumShares.cpp
@@ -1,0 +1,62 @@
+#include <iostream>
+#include <Windows.h>
+#include <winnetwk.h>
+#include <algorithm>
+#include <string>
+
+#pragma comment(lib, "Mpr.lib")
+
+void EnumerateResources(LPNETRESOURCEW pRsrc, DWORD scope, DWORD type, DWORD usage) {
+	HANDLE hEnum = NULL;
+	DWORD result = WNetOpenEnumW(scope, type, usage, pRsrc, &hEnum);
+
+	if (result != NO_ERROR) {
+		std::cerr << "WNetOpenEnumW failed with error: " << result << std::endl;
+		return;
+	}
+
+	BYTE buffer[65536];
+	DWORD count;
+	DWORD bufSize;
+
+	do {
+		count = (DWORD)-1;
+		bufSize = sizeof(buffer);
+		result = WNetEnumResourceW(hEnum, &count, buffer, &bufSize);
+
+		if (result == NO_ERROR || result == ERROR_MORE_DATA) {
+			// Results from WNetEnumResource are returned as an array of NETRESOURCE structures
+			LPNETRESOURCEW pNR = (LPNETRESOURCEW)buffer;
+			for (DWORD i = 0; i < count; i++) {
+				std::wstring remoteName_upper;
+				if (pNR[i].lpRemoteName) { // Convert RemoteName to uppercase
+					remoteName_upper = pNR[i].lpRemoteName;
+					std::transform(remoteName_upper.begin(), remoteName_upper.end(), remoteName_upper.begin(), ::towupper);
+				}
+				if (!remoteName_upper.empty() && (remoteName_upper.find(L"VIRTUALBOX") != std::wstring::npos || remoteName_upper.find(L"VBOXSVR") != std::wstring::npos)) {
+					wprintf(L"Found VirtualBox environment! RemoteName: %ls, Provider: %ls\n", pNR[i].lpRemoteName, pNR[i].lpProvider);
+				}
+				else if (pNR[i].lpRemoteName) {
+					wprintf(L"Net resource: %ls , %ls\n",
+						pNR[i].lpRemoteName ? pNR[i].lpRemoteName : L"(null)",
+						pNR[i].lpProvider ? pNR[i].lpProvider : L"(null)");
+				}
+				// If the resource has more children, enumerate them recursively
+				if (pNR[i].dwUsage & RESOURCEUSAGE_CONTAINER) {
+					EnumerateResources(&pNR[i], scope, type, usage);
+				}
+			}
+		}
+		else if (result != ERROR_NO_MORE_ITEMS) {
+			std::cerr << "WNetEnumResourceW failed with error: " << result << std::endl;
+			break;
+		}
+	} while (result == ERROR_MORE_DATA);
+
+	WNetCloseEnum(hEnum);
+}
+
+int main() {
+	EnumerateResources(nullptr, RESOURCE_GLOBALNET, RESOURCETYPE_DISK, 0);
+	return 0;
+}


### PR DESCRIPTION
This provides an alternative method for enumerating VirtualBox artifacts discovered in a real malware sample. Since it differs from the original method, I believe it may go undetected. I have not added YARA or CAPA rules because the only detectable elements are the two Win32 APIs, which could result in too many false positives, making them less useful. Consider this technique when analyzing an evasive sample.