### PR TITLE
Bochs cpu technique fix

### DIFF
--- a/techniques/bochs_cpu/bochs_cpu.cpp
+++ b/techniques/bochs_cpu/bochs_cpu.cpp
@@ -135,9 +135,32 @@ bool bochs_cpu() {
         constexpr std::uint8_t AMD_K7 = 6;
         constexpr std::uint8_t AMD_K8 = 15;
 
-        const std::uint32_t family = ((eax >> 8) & 0xF);
+        auto is_k7 = [](const u32 eax) -> bool {
+            const std::uint32_t family = (eax >> 8) & 0xF;
+            const std::uint32_t model = (eax >> 4) & 0xF;
+            const std::uint32_t extended_family = (eax >> 20) & 0xFF;
 
-        if (family != AMD_K7 && family != AMD_K8) {
+            if (family == 6 && extended_family == 0) {
+                if (model == 1 || model == 2 || model == 3 || model == 4) {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        auto is_k8 = [](const u32 eax) -> bool {
+            const std::uint32_t family = (eax >> 8) & 0xF;
+            const std::uint32_t extended_family = (eax >> 20) & 0xFF;
+
+            if (family == 0xF) {
+                if (extended_family == 0x00 || extended_family == 0x01) {
+                    return true;
+                }
+            }
+        };
+
+        if (!(is_k7(eax) || is_k8(eax))) {
             return false;
         }
 

--- a/techniques/bochs_cpu/bochs_cpu.cpp
+++ b/techniques/bochs_cpu/bochs_cpu.cpp
@@ -140,7 +140,7 @@ bool bochs_cpu() {
         constexpr std::uint8_t AMD_K7 = 6;
         constexpr std::uint8_t AMD_K8 = 15;
 
-        auto is_k7 = [](const u32 eax) -> bool {
+        auto is_k7 = [](const std::uint32_t eax) -> bool {
             const std::uint32_t family = (eax >> 8) & 0xF;
             const std::uint32_t model = (eax >> 4) & 0xF;
             const std::uint32_t extended_family = (eax >> 20) & 0xFF;
@@ -154,7 +154,7 @@ bool bochs_cpu() {
             return false;
         };
 
-        auto is_k8 = [](const u32 eax) -> bool {
+        auto is_k8 = [](const std::uint32_t eax) -> bool {
             const std::uint32_t family = (eax >> 8) & 0xF;
             const std::uint32_t extended_family = (eax >> 20) & 0xFF;
 

--- a/techniques/bochs_cpu/bochs_cpu.cpp
+++ b/techniques/bochs_cpu/bochs_cpu.cpp
@@ -158,6 +158,8 @@ bool bochs_cpu() {
                     return true;
                 }
             }
+
+            return false;
         };
 
         if (!(is_k7(eax) || is_k8(eax))) {


### PR DESCRIPTION
I've messed up by forgetting to add the model and extension family for the CPU steppings to detect whether it's a K7 or K8 AMD CPU for the bochs technique I published a few days ago, my bad.

I've also added additional checks which should've been added sooner.