### PR TITLE
fix ConnectedPrinters c implementation

### DIFF
--- a/techniques/ConnectedPrinter/c/README.md
+++ b/techniques/ConnectedPrinter/c/README.md
@@ -1,0 +1,14 @@
+# *Connected printers*
+
+## Authorship information
+* Nickname: *Sems*
+* Github: *https://github.com/SemsYapar*
+
+## Technique Information
+* Technique Title: **U1309 - Connected Printer**
+* Technique category: **Sandbox Evasion**
+* Technique description: Same as the already existing description
+
+## Additional resources
+
+## Detection rules

--- a/techniques/ConnectedPrinter/c/main.c
+++ b/techniques/ConnectedPrinter/c/main.c
@@ -1,0 +1,20 @@
+#include <windows.h>
+#include <stdio.h>
+
+int main() {
+    DWORD pcbNeeded;
+    DWORD pcReturned;
+
+    if (!EnumPrinters(PRINTER_ENUM_LOCAL, NULL, 2, NULL, 0, &pcbNeeded, &pcReturned)) {
+        if (GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+            PRINTER_INFO_2* pPrinterEnum = (PRINTER_INFO_2*)malloc(pcbNeeded);
+            if (EnumPrinters(PRINTER_ENUM_LOCAL, NULL, 2, (LPBYTE)pPrinterEnum, pcbNeeded, &pcbNeeded, &pcReturned)) {
+                printf("Printer number: %d\n", pcReturned);
+                for (int i = 0; i < pcReturned; i++) {
+                    printf("printerName %ls\n", pPrinterEnum[i].pPrinterName);
+                }
+            }
+            free(pPrinterEnum);
+        }
+    }
+}


### PR DESCRIPTION
# *Connected printers*

## Authorship information
* Nickname: *Sems*
* Github: *https://github.com/SemsYapar*

## Technique Information
* Technique Title: **U1309 - Connected Printer**
* Technique category: **Sandbox Evasion**
* Technique description: Same as the already existing description

## Fix
### Firstly here API info
```c
BOOL EnumPrinters(
  _In_  DWORD   Flags,
  _In_  LPTSTR  Name,
  _In_  DWORD   Level,
  _Out_ LPBYTE  pPrinterEnum,
  _In_  DWORD   cbBuf,
  _Out_ LPDWORD pcbNeeded,
  _Out_ LPDWORD pcReturned
);
```
---
````c
if (EnumPrinters(PRINTER_ENUM_LOCAL, NULL, 2, NULL, 0, &numPrinters, NULL)) {
````

this line broke because EnumPrinters API return error in this scenario

--- 

pcbNeeded does not mean numPrinters, the argument that gives the numPrinters information is pcReturned, but current implementation has given it to the API as NULL, so the API cannot work properly and return 0x57 (ERROR_INVALID_PARAMETER)

 --- 

```c
printerInfo = (PRINTER_INFO_2*)malloc(pcbNeeded * sizeof(PRINTER_INFO_2));
```
this part does not effect progress but its not true for document because [enumprinter_msdn](https://learn.microsoft.com/tr-tr/windows/win32/printdocs/enumprinters)
says pcbNeeded = A pointer to a value that receives the number of bytes copied if the function succeeds or the number of bytes required if cbBuf is too small.
so all we need use pcbNeeded size to malloc

